### PR TITLE
Solve n+1 queries

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: #1 Improve scores feed performance

**Changes**

Added eagerly loading in `scores controller`, method `user_feed`. Lazy loading was making new queries to get the user for every score from feed.

**Before**

<img width="1440" alt="n+1_before" src="https://user-images.githubusercontent.com/93521998/145578060-c77b6ccf-286c-4e7a-9af4-c75918337aee.png">


**After**

<img width="1440" alt="n+1_before" src="https://user-images.githubusercontent.com/93521998/145578071-458e2d43-5d04-49a9-86b1-d19cb3f005b2.png">



Screenshot after the change.
