### PR TITLE
Solved n+1 queries problem.

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [issue url](https://github.com/GeorgeMarcus/golfr_backend/issues/1)

Fixed n+1 queries problem by adopting eager loading.

**Changes**

Added includes(:user) to make sure the associated user is loaded with score. Because it knows what user needs to be loaded beforehand, it can fetch all users of all requested scores in one query.

**Before**

(Lazy loading) A select user query is made for each score.

<img width="879" alt="Screenshot 2021-12-14 at 15 51 26" src="https://user-images.githubusercontent.com/93124356/146015513-ae1be7a2-f36d-477a-8bd4-5f095e140e41.png">

**After**

(Eager loading) Only one select query is needed to get users.

<img width="879" alt="Screenshot 2021-12-14 at 15 52 27" src="https://user-images.githubusercontent.com/93124356/146015553-a2a0e03a-4603-400a-b43f-fad650e8782e.png">
