### PR TITLE
Improve feed performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /config/database.yml
 .DS_Store
 /storage/*
+
+.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/1 

**Changes**

The `user_feed` method now uses eager loading instead of lazy loading when fetching the user associated with each score.

**Before**

<img width="937" alt="Screenshot 2021-12-22 at 14 03 39" src="https://user-images.githubusercontent.com/93763306/147091782-02919207-6354-4d0d-92fe-c536f2265db7.png">

**After**

<img width="975" alt="Screenshot 2021-12-22 at 14 04 48" src="https://user-images.githubusercontent.com/93763306/147091818-57f8690d-a00e-4592-af2f-1b5a98452b3c.png">
