### PR TITLE
Solved the n + 1 queries problem using eager loading

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).all.order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: issue url

**Changes**

I resolved the n + 1 queries problem by replacing the lazy association of the users to the scores with an eager one.

**Before**

<img width="830" alt="Before(lazy)" src="https://user-images.githubusercontent.com/56991417/172050078-90e21e5c-e59b-45f1-8037-501288a07048.png">


**After**

<img width="855" alt="After(eager)" src="https://user-images.githubusercontent.com/56991417/172050229-c9b8c8b3-e2ad-484d-a903-52f18b1f8f4c.png">

