### PR TITLE
Fix n+1 queries scores feed performance issue

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [scores feed performance](https://github.com/GeorgeMarcus/golfr_backend/compare/main...costinaandrici:golfr_backend:hotfix/url)

**Changes**

Until now, the Lazy loading used when getting the scores feed was causing extra queries to be executed ([N+1 problem](https://github.com/GeorgeMarcus/golfr_backend/compare/main...costinaandrici:golfr_backend:hotfix/url)).
Solved the issue by using Eager loading, making sure we execute only the necessary queries.

**Before**

Queries executed with lazy loading:
[
<img width="851" alt="Screenshot 2022-08-01 at 12 37 03" src="https://user-images.githubusercontent.com/108520650/182129705-75f7bbd8-524f-4108-ab78-340a7ad294b2.png">
](url)

**After**

Queries executed with eager loading:
<img width="903" alt="Screenshot 2022-08-01 at 12 36 02" src="https://user-images.githubusercontent.com/108520650/182129762-8f89fd4d-26d1-487d-bcd7-fb5c84a4097b.png">

