### PR TITLE
N+1 query resolved

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,12 +69,12 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    # config.default_formatter = "doc"
-  end
+  # if config.files_to_run.one?
+  #   # Use the documentation formatter for detailed output,
+  #   # unless a formatter has already been configured
+  #   # (e.g. via a command-line flag).
+  #   # config.default_formatter = "doc"
+  # end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
Fixes: #1 

Changes:

When feed API was requested, users associated with each score were lazy loaded. This generated a different query for each score to load it's user. Now scores eager load users on feed so users are taken at once from the database.

Before:

<img width="926" alt="Screenshot 2022-12-19 at 13 17 26" src="https://user-images.githubusercontent.com/118812336/208414617-ef2c29cc-b161-4fdd-a6c1-9325e4318d81.png">


After:

<img width="999" alt="Screenshot 2022-12-19 at 13 20 00" src="https://user-images.githubusercontent.com/118812336/208414750-5c602fb9-508f-4c18-b7e0-5e93b6519c7a.png">
