### PR TITLE
Fix n + 1 queries issue by eager loading users with scores

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,12 +69,6 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    # config.default_formatter = "doc"
-  end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
I used the "includes" method which uses under the hood two queries that work together so that we can pull the scores ( with the first query ) and then we pull directly the users for those scores ( with the second query, instead of looping through scores and use a query per score )

**Before**

<img width="1440" alt="Screenshot 2024-07-26 at 18 45 00" src="https://github.com/user-attachments/assets/424c6f09-cb24-4020-a1b9-a0f993963210">

**After**


<img width="1440" alt="Screenshot 2024-07-26 at 18 46 57" src="https://github.com/user-attachments/assets/38c9e6bc-9395-4c02-b945-20bc56761279">
