### PR TITLE
Hotfix: optimize /api/feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,8 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      # scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION

**Changes**
Am optimizat metoda user_feed din ScoresController pentru a reduce numărul interogarilor
În loc de Score.all, am folosit Score.includes(:user), ceea ce permite încărcarea utilizatorilor asociați fiecărui scor într-un singur query

**Before**
Pentru fiecare scor, se executa un query separat pentru user.name
În consola Rails apărea câte o interogare către tabela users pentru fiecare scor

**After**
Se execută un singur query SELECT * FROM users WHERE id IN (...)

